### PR TITLE
feat: add picotool_erase tool

### DIFF
--- a/src/picotool_mcp_server/picotool.py
+++ b/src/picotool_mcp_server/picotool.py
@@ -266,3 +266,67 @@ class PicotoolWrapper:
             args.append("-F")
         
         return await self._run_command(args)
+    
+    async def erase(
+        self,
+        all_flash: bool = False,
+        sector: Optional[str] = None,
+        range_start: Optional[str] = None,
+        range_end: Optional[str] = None,
+        force: bool = False,
+        force_no_reboot: bool = False,
+        bus: Optional[str] = None,
+        address: Optional[str] = None,
+        vid: Optional[str] = None,
+        pid: Optional[str] = None,
+        serial: Optional[str] = None
+    ) -> str:
+        """Erase flash memory on connected Pico device.
+        
+        Args:
+            all_flash: Erase all flash memory
+            sector: Erase specific sector (hex address)
+            range_start: Start address for range erase (hex)
+            range_end: End address for range erase (hex)
+            force: Force device not in BOOTSEL mode to reset
+            force_no_reboot: Force device reset but don't reboot back
+            bus: Filter devices by USB bus number
+            address: Filter devices by USB device address
+            vid: Filter by vendor ID
+            pid: Filter by product ID
+            serial: Filter by serial number
+            
+        Returns:
+            Erase command output from picotool
+        """
+        args = ["erase"]
+        
+        # Add erase options
+        if all_flash:
+            args.append("--all")
+        elif sector:
+            args.extend(["--sector", sector])
+        elif range_start and range_end:
+            args.extend(["--range", f"{range_start}:{range_end}"])
+        elif range_start or range_end:
+            raise PicotoolError("Both range_start and range_end must be specified for range erase")
+        
+        # Add device selection options
+        if bus:
+            args.extend(["--bus", bus])
+        if address:
+            args.extend(["--address", address])
+        if vid:
+            args.extend(["--vid", vid])
+        if pid:
+            args.extend(["--pid", pid])
+        if serial:
+            args.extend(["--ser", serial])
+        
+        # Add force options (must be last)
+        if force:
+            args.append("-f")
+        elif force_no_reboot:
+            args.append("-F")
+        
+        return await self._run_command(args)

--- a/src/picotool_mcp_server/server.py
+++ b/src/picotool_mcp_server/server.py
@@ -216,6 +216,63 @@ async def list_tools() -> list[types.Tool]:
                 },
                 "additionalProperties": False
             }
+        ),
+        types.Tool(
+            name="picotool_erase",
+            description="Erase flash memory on connected Pico devices. CAUTION: This operation is destructive and will permanently delete data.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "all_flash": {
+                        "type": "boolean",
+                        "description": "Erase all flash memory on the device",
+                        "default": False
+                    },
+                    "sector": {
+                        "type": "string",
+                        "description": "Erase specific sector (hex address, e.g. '0x10000000')"
+                    },
+                    "range_start": {
+                        "type": "string",
+                        "description": "Start address for range erase (hex, e.g. '0x10000000')"
+                    },
+                    "range_end": {
+                        "type": "string",
+                        "description": "End address for range erase (hex, e.g. '0x10100000')"
+                    },
+                    "force": {
+                        "type": "boolean",
+                        "description": "Force device not in BOOTSEL mode to reset",
+                        "default": False
+                    },
+                    "force_no_reboot": {
+                        "type": "boolean",
+                        "description": "Force device reset but don't reboot back",
+                        "default": False
+                    },
+                    "bus": {
+                        "type": "string",
+                        "description": "Filter devices by USB bus number"
+                    },
+                    "address": {
+                        "type": "string",
+                        "description": "Filter devices by USB device address"
+                    },
+                    "vid": {
+                        "type": "string",
+                        "description": "Filter by vendor ID"
+                    },
+                    "pid": {
+                        "type": "string",
+                        "description": "Filter by product ID"
+                    },
+                    "serial": {
+                        "type": "string",
+                        "description": "Filter by serial number"
+                    }
+                },
+                "additionalProperties": False
+            }
         )
     ]
 
@@ -349,6 +406,43 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> Sequence[typ
             
         except Exception as e:
             error_msg = f"Error running picotool partition info: {str(e)}"
+            logger.error(error_msg)
+            return [types.TextContent(type="text", text=error_msg)]
+    
+    elif name == "picotool_erase":
+        try:
+            all_flash = arguments.get("all_flash", False)
+            sector = arguments.get("sector")
+            range_start = arguments.get("range_start")
+            range_end = arguments.get("range_end")
+            force = arguments.get("force", False)
+            force_no_reboot = arguments.get("force_no_reboot", False)
+            bus = arguments.get("bus")
+            address = arguments.get("address")
+            vid = arguments.get("vid")
+            pid = arguments.get("pid")
+            serial = arguments.get("serial")
+            
+            logger.info(f"Running picotool erase with options={arguments}")
+            
+            result = await picotool.erase(
+                all_flash=all_flash,
+                sector=sector,
+                range_start=range_start,
+                range_end=range_end,
+                force=force,
+                force_no_reboot=force_no_reboot,
+                bus=bus,
+                address=address,
+                vid=vid,
+                pid=pid,
+                serial=serial
+            )
+            
+            return [types.TextContent(type="text", text=result)]
+            
+        except Exception as e:
+            error_msg = f"Error running picotool erase: {str(e)}"
             logger.error(error_msg)
             return [types.TextContent(type="text", text=error_msg)]
     


### PR DESCRIPTION
## Summary
Adds `picotool_erase` tool to the MCP server, enabling destructive flash memory operations on Raspberry Pi Pico devices.

## Features
- **All flash erase**: Complete device flash memory erasure using `--all` flag
- **Sector-specific erase**: Target specific sectors with hex addresses (`--sector`)
- **Range erase**: Erase memory ranges with start:end hex addresses (`--range`)
- **Device selection**: Full support for bus, address, VID, PID, and serial filtering
- **Force modes**: Options for forcing device reset and controlling reboot behavior

## Safety Features
- Clear warning in tool description about destructive nature
- Input validation requiring both start and end addresses for range operations
- Comprehensive error handling following MCP protocol standards

## Test Plan
- [x] Verify tool registration and listing
- [x] Test command argument construction for all erase modes
- [x] Validate device selection parameter handling
- [x] Confirm MCP protocol compliance